### PR TITLE
Update ColorProvider.java

### DIFF
--- a/src/main/java/us/eunoians/prisma/ColorProvider.java
+++ b/src/main/java/us/eunoians/prisma/ColorProvider.java
@@ -80,7 +80,7 @@ public class ColorProvider {
     public static String translatePrisma(String message, boolean returnWithVanillaColor) {
         StringBuilder builder = new StringBuilder();
         boolean isColor = false;
-        char colorCode = '&';
+        char colorCode = '^';
 
         // Loop through all the characters in the message
         for (char letter : message.toCharArray()) {
@@ -109,7 +109,7 @@ public class ColorProvider {
                 continue;
             }
 
-            if (letter == '&' || letter == '§') {
+            if (letter == '^' || letter == '§') {
                 isColor = true;
                 colorCode = letter;
                 continue;


### PR DESCRIPTION
Keep the &<1-9,a-f> Vanilla color codes while allowing a new set of color codes using ^<1-9,a-z> be created. I am guessing that creating codes like &11 or &aa would result in the original codes, &1 and &a, being used to color the subsequent characters. If the limit of creating new color codes is stemmed from this, then having new characters to activate color codes, like '^' in this example, would allow server owners to add 37 new color codes, as opposed to the cap set currently when the defaults are included (which is 20 fewer because of default codes). 

If this isn't functional, or if the hypothesis I have is false, then please disregard.