### PR TITLE
Translate to Hex

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 //from now on this is how you'll change version
-def versionObj = new Version(major: 1, minor: 0, state: 'RELEASE')
+def versionObj = new Version(major: 1, minor: 1, state: 'RELEASE')
 
 group 'us.eunoians'
 version = "${versionObj.toString()}"

--- a/src/main/java/us/eunoians/prisma/ColorProvider.java
+++ b/src/main/java/us/eunoians/prisma/ColorProvider.java
@@ -70,6 +70,53 @@ public class ColorProvider {
     }
 
     /**
+     * Translates a messages prisma custom color codes into hex codes prepended with '#'
+     *
+     * @param message The message to translate with custom color codes
+     * @return The translated prisma message, containing hex codes
+     */
+    public static String translatePrismaToHex(String message) {
+        return translatePrismaToHex(message, true);
+    }
+
+    /**
+     * Translates a messages prisma custom color codes into hex codes
+     *
+     * @param message The message to translate with custom color codes
+     * @param prepend Whether to prepend color codes with '#'
+     * @return The translated prisma message, containing hex codes
+     */
+    public static String translatePrismaToHex(String message, boolean prepend) {
+        StringBuilder builder = new StringBuilder();
+        boolean isColor = false;
+
+        // Loop through all the characters in the message
+        for (char letter : message.toCharArray()) {
+            if (letter == '&' || letter == '§') {
+                isColor = true;
+                continue;
+            }
+
+            // If the letter is a colour code append the colour to the message
+            if (isColor) {
+                isColor = false;
+
+                // Translate the colours registered in the colour map
+                if (colorMap.containsKey(letter)) {
+
+                    // Append the hex colour to the colour map
+                    builder.append(colorMap.get(letter).toHex(prepend));
+                    continue;
+                }
+            }
+
+            builder.append(letter);
+        }
+
+        return builder.toString();
+    }
+
+    /**
      * Translates a message with custom colour codes from the colors.yml
      *
      * @param message                The message to translate with custom color codes
@@ -175,7 +222,22 @@ public class ColorProvider {
          * @return - a hexadecimal string representation of the colours in this {@link RGBWrapper}
          */
         public String toHex() {
-            return String.format("#%02x%02x%02x", red, green, blue);
+            return toHex(true);
+        }
+
+        /**
+         * Convert the RGB colour components to a hex colour
+         *
+         * @param prepend Whether to prepend the color code with '#'
+         * @return - a hexadecimal string representation of the colours in this {@link RGBWrapper}
+         */
+        public String toHex(boolean prepend) {
+            StringBuilder builder = new StringBuilder();
+            if (prepend) {
+                builder.append("#");
+            }
+            builder.append(String.format("%02x%02x%02x", red, green, blue));
+            return builder.toString();
         }
 
         /**

--- a/src/main/java/us/eunoians/prisma/PrismaColor.java
+++ b/src/main/java/us/eunoians/prisma/PrismaColor.java
@@ -148,6 +148,15 @@ public enum PrismaColor {
     private final String hex;
 
     /**
+     * Get the Hex code of the {@link PrismaColor}.
+     *
+     * @return The Hex code ie '#A52A2A'
+     */
+    public String getHex() {
+        return hex;
+    }
+
+    /**
      * Construct a new {@link PrismaColor}.
      *
      * @param hex - the hex of the colour
@@ -155,7 +164,6 @@ public enum PrismaColor {
     PrismaColor(String hex) {
         this.hex = hex;
     }
-
 
     @Override
     public String toString() {


### PR DESCRIPTION
Prisma colors are more easily usable in other formats if translated to a hex code.
For example I can use [MiniMessage](https://github.com/KyoriPowered/adventure-text-minimessage) for my message parsing, and use prisma colors like so:
```xml
<rainbow>Prisma</rainbow> <color:&?>Test: <color:&x>Hello</color:&x> !!!! </color:&?>
```
[![https://imgur.com/FiO2nf5.png](https://imgur.com/FiO2nf5.png)](https://imgur.com/FiO2nf5.png)
All that is required for me to implement this in my plugin is adding this to the beginning of my message sending helper method
```java
message = ColorProvider.translatePrismaToHex(message);
```